### PR TITLE
Using EC2 roles and latest R

### DIFF
--- a/emr-3.2.1/scripts/install-tessera-master.sh
+++ b/emr-3.2.1/scripts/install-tessera-master.sh
@@ -39,6 +39,9 @@ installRstudioPro(){
     sudo rstudio-server restart
 }
 
+# Upgrades R
+sudo yum update R.x86_64 -y
+
 # installRstudioPro
 installRstudio
 

--- a/emr-3.2.1/scripts/install-tessera.sh
+++ b/emr-3.2.1/scripts/install-tessera.sh
@@ -5,6 +5,9 @@
 # this produces errors
 # R 3.0.2 already installed
 
+# Updating R
+sudo yum update R.x86_64 -y
+
 ## CONFIG
 function eVal {
     echo $1 | tee -a /home/hadoop/.Renviron

--- a/emr-3.2.1/tessera-emr.sh
+++ b/emr-3.2.1/tessera-emr.sh
@@ -28,7 +28,7 @@ EOF
 
 N_WORKERS=2
 S3_BUCKET=
-MASTER_TYPE=m1.large
+MASTER_TYPE=m1.xlarge
 WORKER_TYPE=m1.large
 USER=tessera-user
 PASSWD=tessera
@@ -150,9 +150,10 @@ CLUSTER_ID=$(aws emr create-cluster \
 --name "Tessera" \
 --enable-debugging --log-uri $S3_BUCKET/logs \
 --ami-version 3.2.1 \
---no-auto-terminate \
 --emrfs Consistent=True \
+--no-auto-terminate \
 --no-visible-to-all-users \
+--use-default-roles \
 --instance-groups InstanceGroupType=MASTER,InstanceCount=1,InstanceType=$MASTER_TYPE InstanceGroupType=CORE,InstanceCount=$N_WORKERS,InstanceType=$WORKER_TYPE \
 --ec2-attributes KeyName=$KEY_PAIR_NAME,AdditionalMasterSecurityGroups=[$SEC_GROUP_ID] \
 --bootstrap-actions Path=s3://elasticmapreduce/bootstrap-actions/configure-hadoop,Args=[\


### PR DESCRIPTION
Using EC2 Roles when launching the cluster (`use-default-roles` flag).
Updates R to the latest version in all node types.
